### PR TITLE
Feature/11 gcal details

### DIFF
--- a/band-website/src/app/home/home.component.html
+++ b/band-website/src/app/home/home.component.html
@@ -24,12 +24,20 @@
   
       <ul class="event-list" *ngIf="upcomingEvents.length > 0">
         <li *ngFor="let event of upcomingEvents" class="event-item">
-          <h3 class="event-summary">{{ event.summary }}</h3>
+          <h3 class="event-summary">
+            <ng-container *ngIf="extractUrlFromDescription(event.description) as eventUrl; else plainTitle">
+              <a [href]="eventUrl" target="_blank" rel="noopener noreferrer">{{ event.summary }}</a>
+            </ng-container>
+            <ng-template #plainTitle >
+              <span class="noUrl">{{ event.summary }}</span>
+            </ng-template>
+          </h3>
           <p class="event-time">{{ formatEventTime(event) }}</p>
-          <p class="event-link" *ngIf="event.htmlLink">
-            <a [href]="event.htmlLink" target="_blank" rel="noopener noreferrer">View Details</a>
+          <p class="event-location" *ngIf="event.location">
+            <a [href]="createGoogleMapsLink(event.location)" target="_blank" rel="noopener noreferrer">{{ event.location }}</a>
           </p>
         </li>
       </ul>
     </div>
+
   </section>

--- a/band-website/src/app/home/home.component.scss
+++ b/band-website/src/app/home/home.component.scss
@@ -120,18 +120,28 @@
     font-size: 1.2em;
   }
 
+  .event-summary a, .noUrl {
+    color: #e46905;
+    text-decoration: none;
+    font-size: 0.9em;
+  }
+
+  .event-summary a:hover {
+    text-decoration: underline;
+  }
+
   .event-time {
     margin: 0;
     color: #555;
     font-size: 0.9em;
   }
 
-  .event-link a {
-    color: #e46905;
+  .event-location a {
+   // color: #e46905;
     text-decoration: none;
     font-size: 0.9em;
   }
 
-  .event-link a:hover {
+  .event-location a:hover {
     text-decoration: underline;
   }

--- a/band-website/src/app/home/home.component.ts
+++ b/band-website/src/app/home/home.component.ts
@@ -37,28 +37,84 @@ export class HomeComponent implements OnInit {
     });
   }
 
+  /**
+   * Extracts the first URL found in an event's description.
+   * @param description The event description string.
+   * @returns A URL string or null if not found.
+   */
+
+  extractUrlFromDescription(description: string | undefined): string | null {
+    if (!description) {
+      return null;
+    }
+    // Simple regex to find the first http or https URL
+    const urlRegex = /(https?:\/\/[^\s"<]+)/g;
+    const found = description.match(urlRegex);
+    return found ? found[0] : null;
+  }
+
+  /**
+   * Creates a Google Maps search link from a location string.
+   * @param location The location string from the event.
+   * @returns A URL for Google Maps or null if no location.
+   */
+  createGoogleMapsLink(location: string | undefined): string | null {
+    if (!location) {
+      return null;
+    }
+    // URL-encodes the location for the query parameter
+    const encodedLocation = encodeURIComponent(location);
+    return `https://www.google.com/maps/search/?api=1&query=${encodedLocation}`;
+  }
+
   // Helper function to format dates for display
   formatEventTime(event: CalendarEvent): string {
-    if (event.start.dateTime) {
+    if (event.start.dateTime && event.end.dateTime) {
       // For specific date and time
-      const date = new Date(event.start.dateTime);
-      return date.toLocaleDateString('en-US', {
+      const startDate = new Date(event.start.dateTime);
+      const endDate = new Date(event.end.dateTime);
+      
+      const datePart = startDate.toLocaleDateString('en-US', {
         weekday: 'short',
         month: 'short',
         day: 'numeric',
+      });
+
+      const startTime = startDate.toLocaleTimeString('en-US', {
         hour: 'numeric',
         minute: 'numeric',
         hour12: true
       });
-    } else if (event.start.date) {
-      // For all-day events (only date available)
-      const date = new Date(event.start.date);
-      return date.toLocaleDateString('en-US', {
+
+      const endTime = endDate.toLocaleTimeString('en-US', {
+        hour: 'numeric',
+        minute: 'numeric',
+        hour12: true
+      });
+      
+      return `${datePart}, ${startTime} - ${endTime}`;
+    }
+
+// For all-day events (only date available)
+else if (event.start.date) {
+    // Parse the date string 'YYYY-MM-DD'
+    const dateString = event.start.date;
+    const parts = dateString.split('-');
+    
+    // Construct a new Date object using local time zone, avoiding UTC conversion
+    const year = parseInt(parts[0], 10);
+    const month = parseInt(parts[1], 10) - 1; // Month is 0-indexed
+    const day = parseInt(parts[2], 10);
+    
+    const date = new Date(year, month, day);
+
+    return date.toLocaleDateString('en-US', {
         weekday: 'short',
         month: 'short',
         day: 'numeric'
-      }) + ' (All Day)';
-    }
-    return 'Date/Time TBA';
+    }) + ' (All Day)';
+}
+
+    return '';
   }
 }

--- a/band-website/src/app/services/googlecalendar.service.ts
+++ b/band-website/src/app/services/googlecalendar.service.ts
@@ -14,6 +14,8 @@ export interface CalendarEvent {
   created: string;
   updated: string;
   summary: string;
+  description?: string;
+  location?: string;
   creator: {
     email: string;
     self: boolean;


### PR DESCRIPTION
Adding Calendar details - 
- provide start/end time
- handle UTC for all day events
- if location is available, display underneath listing with link to Google Maps
- if url is in description for event, apply to the event summary to open venue website in a new tab